### PR TITLE
Add CI with docs

### DIFF
--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -26,16 +26,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           channels: defaults,conda-forge
           environment-file: environment.yml
-          use-only-tar-bz2: true
-      - name: Lint with flake8
-        shell: pwsh
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # all Python files should follow PEP8 (except some notebooks, see setup.cfg)
-          flake8 hcrystalball tests
-          # exit-zero treats all errors as warnings.
-          flake8 . --count --exit-zero --max-complexity=10 --statistics
+          use-only-tar-bz2: true     
       - name: Install from source
         # This is required for the pre-commit tests
         shell: pwsh

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,2 @@
+conda:
+  environment: environment.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,2 +1,9 @@
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
 conda:
   environment: environment.yml

--- a/environment.yml
+++ b/environment.yml
@@ -30,3 +30,4 @@ dependencies:
   - tbats==1.0.10 #(T)BATSWrapper, pinning patch version needed to to change in 1.0.3
   - pytest # to run tests
   - pytest-cov # to run tests
+  - . # for the docs build


### PR DESCRIPTION
Add CI over Github actions running tests and enable the build and hosting of the docs on readthedocs.io