### PR TITLE
Cli progress bars

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+Version 0.1.6
+=============
+
+- Fix country column handling in ModelSelector
+- Improved experience of trying examples through Binder (pre-cached docker image)
+- Adding templates for GitHub issues
+
 Version 0.1.5
 =============
 

--- a/src/hcrystalball/model_selection/_large_scale_cross_validation.py
+++ b/src/hcrystalball/model_selection/_large_scale_cross_validation.py
@@ -102,7 +102,7 @@ def select_model(
         leave=True,
         desc="Select Models"
         if parallel_over_dict is None
-        else f"{list(parallel_over_dict.keys())[0]}:{list(parallel_over_dict.values())[0]}",
+        else (", ").join([f"{k}: {v}" for k, v in parallel_over_dict.items()]),
     )
 
     # run model selection and create result object for each data partition

--- a/src/hcrystalball/model_selection/_large_scale_cross_validation.py
+++ b/src/hcrystalball/model_selection/_large_scale_cross_validation.py
@@ -1,7 +1,9 @@
 import itertools
 from copy import deepcopy
-
 import pandas as pd
+import sys
+import io
+
 from ._data_preparation import partition_data
 from ._data_preparation import filter_data
 from ._data_preparation import prepare_data_for_training
@@ -25,18 +27,18 @@ def make_progress_bar(*args, **kwargs):
     iterable or tqdm_notebook
         tqdm_notebook based progress bar or simple iterable
     """
+    pbar = args[0]
     try:
-        from tqdm.notebook import tqdm_notebook
+        from tqdm.auto import tqdm as tqdm_auto
 
-        pbar = tqdm_notebook(*args, **kwargs)
-    except Exception:
+        pbar = tqdm_auto(*args, **kwargs)
+    except Exception as e:
         logging.warning(
             "No prerequisites (tqdm) installed for interactive progress bar, "
             "continuing without one. See the output in the console "
-            "or check installation instructions"
+            "or check installation instructions."
+            f"{e}"
         )
-        return args[0]
-
     return pbar
 
 
@@ -93,12 +95,19 @@ def select_model(
     else:
         df_cv = partition_data(df, list(set(partition_columns).difference(parallel_partition)))
 
-    # will show progress bar only when running not parallel execution, otherwise loop over labels and data
-    pbar = zip(df_cv["labels"], df_cv["data"])
-    if not parallel_partition:
-        pbar = make_progress_bar(pbar, total=len(df_cv["labels"]), leave=True, desc="select model")
+    # will define progress bar if dependencies installed
+    pbar = make_progress_bar(
+        zip(df_cv["labels"], df_cv["data"]),
+        total=len(df_cv["labels"]),
+        leave=True,
+        desc="Select Models"
+        if parallel_over_dict is None
+        else f"{list(parallel_over_dict.keys())[0]}:{list(parallel_over_dict.values())[0]}",
+    )
+
     # run model selection and create result object for each data partition
     for non_parallel_partition, data_part in pbar:
+        # for non_parallel_partition, data_part in zip(df_cv["labels"], df_cv["data"]):
         grid_search_tmp = deepcopy(grid_search)
         X, y = data_part.drop(target_col_name, axis=1), data_part[target_col_name]
         if hasattr(grid_search_tmp, "autosarimax"):
@@ -300,7 +309,6 @@ def run_model_selection(
         - flow itself
         - state of computations
     """
-
     from prefect.utilities.debug import raise_on_exception
 
     flow = _define_model_selection_flow()


### PR DESCRIPTION
Adds progress bars also to parallel execution and when executed from command line/python script.

Tried to use enlighten for python script/cli, but as console output with tqdm is rather easy to find, did not want to add logic to check from where the function is executed and make that switch.

Parallel execution uses parallel_over_columns and its values in the progress bar description
Python script
![image](https://user-images.githubusercontent.com/12393430/88898798-8beb7480-d24d-11ea-86bd-68f80476150a.png)
Jupyter
![image](https://user-images.githubusercontent.com/12393430/88899436-55fac000-d24e-11ea-9eba-57edf7cf7e98.png)


Nonparallel execution uses a simple "Select Models" description
Python script 
![image](https://user-images.githubusercontent.com/12393430/88899178-07e5bc80-d24e-11ea-8620-20f459e4bba1.png)
Jupyter
![image](https://user-images.githubusercontent.com/12393430/88899354-395e8800-d24e-11ea-8dd5-ab80d3986d3b.png)

