### PR TITLE
Extend holiday and seasonality transformers by new features

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,4 @@ repos:
     hooks:
     -   id: nbstripout
         files: ".ipynb"
+        args: [--line-length="metadata.celltoolbar cell.metadata.heading_collapsed"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,4 +19,4 @@ repos:
     hooks:
     -   id: nbstripout
         files: ".ipynb"
-        args: [--line-length="metadata.celltoolbar cell.metadata.heading_collapsed"]
+        args: [--extra-keys=metadata.kernel_spec.display_name metadata.kernel_spec.name]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v3.2.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
     -   id: black
         args: [--line-length=110]
@@ -15,7 +15,7 @@ repos:
     hooks:
     -   id: flake8
 -   repo: https://github.com/kynan/nbstripout
-    rev: master
+    rev: 0.3.9
     hooks:
     -   id: nbstripout
         files: ".ipynb"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,4 +19,3 @@ repos:
     hooks:
     -   id: nbstripout
         files: ".ipynb"
-        args: [--extra-keys=metadata.kernel_spec.display_name metadata.kernel_spec.name]

--- a/docs/examples/tutorial/wrappers/01_wrappers_intro.ipynb
+++ b/docs/examples/tutorial/wrappers/01_wrappers_intro.ipynb
@@ -170,7 +170,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "All models which support confidence intervals in predictions have also possibility to return them - they will be returned as {name of the wrapper}_lower / _upper"
+    "All models which support confidence intervals in predictions have also possibility to return them - they will be returned as {name of the wrapper}_lower / _upper."
    ]
   },
   {

--- a/docs/examples/tutorial/wrappers/01_wrappers_intro.ipynb
+++ b/docs/examples/tutorial/wrappers/01_wrappers_intro.ipynb
@@ -336,9 +336,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hcrystalball",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "hcrystalball"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/tutorial/wrappers/01_wrappers_intro.ipynb
+++ b/docs/examples/tutorial/wrappers/01_wrappers_intro.ipynb
@@ -255,13 +255,90 @@
     "- SimpleSmoothingWrapper\n",
     "- HoltSmoothingWrapper"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "hcrystalball",
    "language": "python",
-   "name": "python3"
+   "name": "hcrystalball"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/tutorial/wrappers/02_ar_modelling_in_sklearn.ipynb
+++ b/docs/examples/tutorial/wrappers/02_ar_modelling_in_sklearn.ipynb
@@ -98,13 +98,27 @@
     ")\n",
     "preds.plot(title=f\"MAE:{(preds['Sales']-preds['sklearn']).abs().mean()}\");"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "hcrystalball",
    "language": "python",
-   "name": "python3"
+   "name": "hcrystalball"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/tutorial/wrappers/02_ar_modelling_in_sklearn.ipynb
+++ b/docs/examples/tutorial/wrappers/02_ar_modelling_in_sklearn.ipynb
@@ -116,9 +116,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hcrystalball",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "hcrystalball"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/tutorial/wrappers/03_sklearn_pipeline.ipynb
+++ b/docs/examples/tutorial/wrappers/03_sklearn_pipeline.ipynb
@@ -141,9 +141,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hcrystalball",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "hcrystalball"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/tutorial/wrappers/03_sklearn_pipeline.ipynb
+++ b/docs/examples/tutorial/wrappers/03_sklearn_pipeline.ipynb
@@ -102,13 +102,48 @@
     "\n",
     "preds.plot(title=f\"MAE:{(preds['Sales']-preds['sklearn']).abs().mean()}\");"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "hcrystalball",
    "language": "python",
-   "name": "python3"
+   "name": "hcrystalball"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/tutorial/wrappers/04_seasonalities_and_holidays.ipynb
+++ b/docs/examples/tutorial/wrappers/04_seasonalities_and_holidays.ipynb
@@ -241,7 +241,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Having individual holidays as separate columns"
+    "### Individual holidays as separate columns"
    ]
   },
   {

--- a/docs/examples/tutorial/wrappers/04_seasonalities_and_holidays.ipynb
+++ b/docs/examples/tutorial/wrappers/04_seasonalities_and_holidays.ipynb
@@ -8,7 +8,7 @@
     "Despite that time-series modeling is not super feature-rich, we can still leverage at least deterministic features which are known in advance - calendar patterns. \n",
     "\n",
     "The easiest way how to model seasonality and leverage the power of ML models is to create a binary feature for each repeating calendar pattern (day of the week, the month of the year...). This is implemented in the \n",
-    "SeasonalityTransformer."
+    "`SeasonalityTransformer`."
    ]
   },
   {
@@ -67,7 +67,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "One of the important parts of time-series modeling is taking into account holidays which in most cases exhibit different behavior than it's common. hcrystalball implements HolidayTransformer which returns column with string name of the holiday based on provided country ISO code for each date in the dataset (empty string if it's not a holiday). All hcrystalball wrappers accept the output of HolidayTransformer and transform it into individual model formats. HolidayTransformer also supports some region specific holidays i.e. Germany state specific holidays, in that case the provided string shoule be in form country-region: i.e. 'DE-HE'."
+    "One of the important parts of time-series modeling is taking into account holidays which in most cases exhibit different behavior than it's common. hcrystalball implements HolidayTransformer which returns column with string name of the holiday based on provided country ISO code for each date in the dataset (empty string if it's not a holiday). All hcrystalball wrappers accept the output of `HolidayTransformer` and transform it into individual model formats. `HolidayTransformer` also supports some region specific holidays i.e. Germany state specific holidays, in that case the provided string shoule be in form country-region: i.e. 'DE-HE'."
    ]
   },
   {
@@ -78,6 +78,23 @@
    "source": [
     "from hcrystalball.feature_extraction import HolidayTransformer\n",
     "HolidayTransformer(country_code = 'DE').fit(X, y).transform(X).tail(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The holiday effects have very often impact on target variable even before or after holidays (i.e. whole Christmas period is affected by few public holidays), in order to model such effects around holiday `HolidayTransformer` provides 3 parameters - `days_before` - number of days the before public holiday which should be taken into account, `days_after` - number of days before the public holiday which should be taken into account and bool variable `bridge_days` which will create variable for the overlaping `days_before` and `days_after` feature - mostly for modeling working days in the middle of two public holidays."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from hcrystalball.feature_extraction import HolidayTransformer\n",
+    "HolidayTransformer(country_code = 'DE', days_before = 2, days_after = 1, bridge_days = True).fit(X, y).transform(X)['2014-04-16':'2014-04-23']"
    ]
   },
   {
@@ -104,7 +121,17 @@
     "from hcrystalball.wrappers import ExponentialSmoothingWrapper\n",
     "from hcrystalball.wrappers import get_sklearn_wrapper\n",
     "from sklearn.ensemble import RandomForestRegressor\n",
-    "from sklearn.pipeline import Pipeline"
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.preprocessing import OneHotEncoder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from hcrystalball.wrappers import SarimaxWrapper"
    ]
   },
   {
@@ -209,13 +236,53 @@
     "\n",
     "preds_col.plot(title=f\"MAE:{(preds_col['Sales'] - preds_col['sklearn']).abs().mean()}\");"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Having individual holidays as separate columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sklearns_native_transformers = TSColumnTransformer(\n",
+    "    transformers=[\n",
+    "        ('one_hot_encoder', OneHotEncoder(sparse=False, drop='first'), ['_holiday_CZ'])\n",
+    "    ])    \n",
+    "\n",
+    "pipeline_col = Pipeline([\n",
+    "   ('holidays', HolidayTransformer(country_code='CZ')),    \n",
+    "    ('one_hot_encoder', sklearns_native_transformers)\n",
+    "]) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline_col.fit_transform(X_col['2013-12-20':'2013-12-26'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "hcrystalball",
    "language": "python",
-   "name": "python3"
+   "name": "hcrystalball"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/tutorial/wrappers/04_seasonalities_and_holidays.ipynb
+++ b/docs/examples/tutorial/wrappers/04_seasonalities_and_holidays.ipynb
@@ -280,9 +280,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hcrystalball",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "hcrystalball"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/tutorial/wrappers/05_model_selection.ipynb
+++ b/docs/examples/tutorial/wrappers/05_model_selection.ipynb
@@ -316,9 +316,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hcrystalball",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "hcrystalball"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/tutorial/wrappers/05_model_selection.ipynb
+++ b/docs/examples/tutorial/wrappers/05_model_selection.ipynb
@@ -263,13 +263,62 @@
    "source": [
     "We can get to the model definitions using hash in `results.scorer_.estimator_ids` dict"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "hcrystalball",
    "language": "python",
-   "name": "python3"
+   "name": "hcrystalball"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/tutorial/wrappers/06_advanced_prophet.ipynb
+++ b/docs/examples/tutorial/wrappers/06_advanced_prophet.ipynb
@@ -240,9 +240,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hcrystalball",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "hcrystalball"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/tutorial/wrappers/06_advanced_prophet.ipynb
+++ b/docs/examples/tutorial/wrappers/06_advanced_prophet.ipynb
@@ -229,13 +229,20 @@
     "     .predict(X[-10:])\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "hcrystalball",
    "language": "python",
-   "name": "python3"
+   "name": "hcrystalball"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/tutorial/wrappers/07_advanced_sarimax.ipynb
+++ b/docs/examples/tutorial/wrappers/07_advanced_sarimax.ipynb
@@ -160,9 +160,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hcrystalball",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "hcrystalball"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/tutorial/wrappers/07_advanced_sarimax.ipynb
+++ b/docs/examples/tutorial/wrappers/07_advanced_sarimax.ipynb
@@ -142,13 +142,27 @@
    "source": [
     "model"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "hcrystalball",
    "language": "python",
-   "name": "python3"
+   "name": "hcrystalball"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/tutorial/wrappers/08_ensembles.ipynb
+++ b/docs/examples/tutorial/wrappers/08_ensembles.ipynb
@@ -178,9 +178,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hcrystalball",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "hcrystalball"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/tutorial/wrappers/08_ensembles.ipynb
+++ b/docs/examples/tutorial/wrappers/08_ensembles.ipynb
@@ -167,13 +167,20 @@
     ")\n",
     "preds.plot(title=f\"MAE:{(preds['Sales']-preds['stacking_ensemble']).abs().mean()}\");"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "hcrystalball",
    "language": "python",
-   "name": "python3"
+   "name": "hcrystalball"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/tutorial/wrappers/09_transforming_target.ipynb
+++ b/docs/examples/tutorial/wrappers/09_transforming_target.ipynb
@@ -152,9 +152,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "hcrystalball",
    "language": "python",
-   "name": "python3"
+   "name": "hcrystalball"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/examples/tutorial/wrappers/09_transforming_target.ipynb
+++ b/docs/examples/tutorial/wrappers/09_transforming_target.ipynb
@@ -152,9 +152,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hcrystalball",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "hcrystalball"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,6 @@ dependencies:
 - nbsphinx # to build docs
 - sphinx_rtd_theme # to build docs
 - sphinx-gallery # to build docs
-- black # to format the code
 - flake8 # to format the code
 - pre-commit # to run pre-commit hooks
 - prefect # to execute model selection in parallel
@@ -32,4 +31,5 @@ dependencies:
   - tbats==1.0.10 #(T)BATSWrapper, pinning patch version needed to to change in 1.0.3
   - pytest # to run tests
   - pytest-cov # to run tests
+  - black # to format the code, moved to pip since conda doesn't have new release yet
   - . # for the docs build, remove when not having cloned git repository and run `pip install hcrystalball` or `conda install -c conda-forge hcrystalball` instead

--- a/src/hcrystalball/feature_extraction/_holiday_transformer.py
+++ b/src/hcrystalball/feature_extraction/_holiday_transformer.py
@@ -15,6 +15,20 @@ class HolidayTransformer(TransformerMixin, BaseEstimator):
     country_code_column: str
         name of the column which have the ISO code of the country/region
 
+    days_before: int
+        number of days before the holiday which will be taken into account
+        (i.e. 2 means that new bool column will be created and will be True for 2 days before holidays,
+        otherwise False)
+
+    days_after: int
+        number of days after the holiday which will be taken into account
+        (i.e. 2 means that new bool column will be created and will be True for 2 days after holidays,
+        otherwise False)
+
+    bridge_days: bool
+        overlaping `days_before` and `days_after` feature which serves for modeling between
+        holidays working days
+
     Please be aware that you cannot provide both country_code and country_code_column
     during initialization since this would be ambuguious. If you provide `country_code_column`
     instead of `country_code` the ISO code found in the column will be assigned into `country_code` column.
@@ -194,6 +208,7 @@ class HolidayTransformer(TransformerMixin, BaseEstimator):
             df = df.assign(**{f"_{col_name}_{day}": lambda df: ((df[self._col_name] != "").shift(day))})
         cols = df.filter(like=f"_{col_name}_").columns
         if days != 0:
+            # all intermediate columns called (i.e. _{`col_name`}_) are combined into one as `col_name`
             df = df.assign(**{f"{col_name}": lambda df: df[cols].any(axis=1)})
 
         return df.drop(cols, axis=1)

--- a/src/hcrystalball/feature_extraction/_holiday_transformer.py
+++ b/src/hcrystalball/feature_extraction/_holiday_transformer.py
@@ -21,7 +21,12 @@ class HolidayTransformer(TransformerMixin, BaseEstimator):
     """
 
     def __init__(
-        self, country_code=None, country_code_column=None, days_before=0, days_after=0, bridge_days=False
+        self,
+        country_code=None,
+        country_code_column=None,
+        days_before=0,
+        days_after=0,
+        bridge_days=False,
     ):
         self.country_code = country_code
         self.unified_country_code = country_code

--- a/src/hcrystalball/feature_extraction/_holiday_transformer.py
+++ b/src/hcrystalball/feature_extraction/_holiday_transformer.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import logging
 from workalendar.registry import registry
 from sklearn.base import BaseEstimator, TransformerMixin
 

--- a/src/hcrystalball/feature_extraction/_seasonal_transformer.py
+++ b/src/hcrystalball/feature_extraction/_seasonal_transformer.py
@@ -34,7 +34,20 @@ class SeasonalityTransformer(BaseEstimator, TransformerMixin):
     """
 
     def __init__(
-        self, auto=True, freq=None, week_day=None, monthly=None, quarterly=None, yearly=None, weekly=None,
+        self,
+        auto=True,
+        freq=None,
+        week_day=None,
+        monthly=None,
+        quarterly=None,
+        yearly=None,
+        weekly=None,
+        month_start=False,
+        month_end=False,
+        quarter_start=False,
+        quarter_end=False,
+        year_start=False,
+        year_end=False,
     ):
         self.auto = auto
         self.freq = freq
@@ -47,6 +60,12 @@ class SeasonalityTransformer(BaseEstimator, TransformerMixin):
         self.quarterly = quarterly
         self.yearly = yearly
         self.weekly = weekly
+        self.month_start = month_start
+        self.month_end = month_end
+        self.quarter_start = quarter_start
+        self.quarter_end = quarter_end
+        self.year_start = year_start
+        self.year_end = year_end
         self._fit_columns = None
 
     def get_feature_names(self):
@@ -137,6 +156,20 @@ class SeasonalityTransformer(BaseEstimator, TransformerMixin):
             season_feat.append(pd.get_dummies(date.year))
 
         _X = pd.concat(season_feat, axis=1)
+
+        if self.month_start:
+            _X["month_start"] = date.is_month_start
+        if self.month_end:
+            _X["month_end"] = date.is_month_end
+        if self.quarter_start:
+            _X["quarter_start"] = date.is_quarter_start
+        if self.quarter_end:
+            _X["quarter_end"] = date.is_quarter_end
+        if self.year_start:
+            _X["year_start"] = date.is_year_start
+        if self.year_end:
+            _X["year_end"] = date.is_year_end
+
         _X.columns = [f"_{col}" for col in _X.columns]
 
         if self._fit_columns is not None:

--- a/src/hcrystalball/wrappers/_prophet.py
+++ b/src/hcrystalball/wrappers/_prophet.py
@@ -139,22 +139,29 @@ class ProphetWrapper(TSModelWrapper):
             Input features without 'holiday' column
         """
 
-        holiday_cols = [col for col in X.filter(like="_holiday_").columns]
+        holiday_cols = [col for col in X.filter(like="_holiday_").select_dtypes(include="object").columns]
 
-        unique_holiday = list(
-            itertools.chain.from_iterable([X.loc[X[col] != "", col].unique() for col in holiday_cols])
-        )
+        unique_holiday_dict = {col: X.loc[X[col] != "", col].unique() for col in holiday_cols}
 
-        # ensure correct handling of extra_holidays parameters
         extra_holidays = {
-            holiday: {"lower_window": 0, "upper_window": 0, "prior_scale": self.holidays_prior_scale}
-            for holiday in unique_holiday
+            col: {
+                holiday: {
+                    "lower_window": self.get_holiday_windows(X, f"_before{col}"),
+                    "upper_window": self.get_holiday_windows(X, f"_after{col}"),
+                    "prior_scale": self.holidays_prior_scale,
+                }
+                for holiday in holidays
+            }
+            for col, holidays in unique_holiday_dict.items()
         }
-        if self.extra_holidays:
-            extra_holidays = deep_dict_update(extra_holidays, self.extra_holidays)
 
+        if self.extra_holidays:
+            extra_holidays = {k: deep_dict_update(v, self.extra_holidays) for k, v in extra_holidays.items()}
+
+        unique_holiday = set(itertools.chain.from_iterable(unique_holiday_dict.values()))
+        all_extra_holidays = set(itertools.chain.from_iterable(extra_holidays.values()))
         if len(unique_holiday) > 0:
-            missing_holidays = set(extra_holidays.keys()).difference(unique_holiday)
+            missing_holidays = all_extra_holidays.difference(unique_holiday)
 
             if missing_holidays:
                 logging.warning(
@@ -176,7 +183,7 @@ class ProphetWrapper(TSModelWrapper):
                     # given the extra_holidays parameter
                     holidays.append(
                         inter.merge(
-                            inter[col].map(extra_holidays).apply(pd.Series),
+                            inter[col].map(extra_holidays[col]).apply(pd.Series),
                             left_index=True,
                             right_index=True,
                         ).loc[:, ["holiday", "lower_window", "upper_window", "prior_scale"]]
@@ -185,6 +192,11 @@ class ProphetWrapper(TSModelWrapper):
             self.model.holidays = pd.concat(holidays).assign(ds=lambda x: x.index).reset_index(drop=True)
 
         return X.drop(columns=holiday_cols, errors="ignore")
+
+    def get_holiday_windows(self, X, col_like):
+        window = X.filter(like=f"{col_like}")
+        window = 0 if window.empty else window.columns[0].split("_")[1]
+        return int(window)
 
     @enforce_y_type
     @check_X_y

--- a/src/hcrystalball/wrappers/_prophet.py
+++ b/src/hcrystalball/wrappers/_prophet.py
@@ -204,6 +204,9 @@ class ProphetWrapper(TSModelWrapper):
         X : pandas.DataFrame
             Input features with 'col_like' column.
 
+        col_like: str
+            col name pattern
+            (i.e. `_before_holiday_DE`)
         Returns
         -------
         int

--- a/src/hcrystalball/wrappers/_sarimax.py
+++ b/src/hcrystalball/wrappers/_sarimax.py
@@ -102,7 +102,12 @@ class SarimaxWrapper(TSModelWrapper):
         -------
         pandas.DataFrame
         """
-        return X.assign(**{col: X[col] != "" for col in X.filter(like="_holiday_").columns})
+        return X.assign(
+            **{
+                col: X[col] != ""
+                for col in X.filter(like="_holiday_").select_dtypes(include="object").columns
+            }
+        )
 
     @enforce_y_type
     @check_X_y
@@ -159,7 +164,9 @@ class SarimaxWrapper(TSModelWrapper):
         preds = pd.DataFrame(preds, index=X.index, columns=[self.name])
         if self.conf_int:
             conf_ints = pd.DataFrame(
-                conf_ints, columns=[f"{self.name}_lower", f"{self.name}_upper"], index=X.index,
+                conf_ints,
+                columns=[f"{self.name}_lower", f"{self.name}_upper"],
+                index=X.index,
             )
             preds = pd.concat([preds, conf_ints], axis=1)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,7 +178,7 @@ def X_with_holidays():
     from hcrystalball.feature_extraction import HolidayTransformer
 
     X = pd.DataFrame(index=pd.date_range(start="2019-01-01", periods=300))
-    holidays = HolidayTransformer(country_code="DE").fit_transform(X)
+    holidays = HolidayTransformer(country_code="DE", days_before=2, days_after=1).fit_transform(X)
     return X.join(holidays)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,11 +174,16 @@ def X_y_optional(request):
 
 
 @pytest.fixture(scope="module")
-def X_with_holidays():
+def X_with_holidays(request):
     from hcrystalball.feature_extraction import HolidayTransformer
 
     X = pd.DataFrame(index=pd.date_range(start="2019-01-01", periods=300))
-    holidays = HolidayTransformer(country_code="DE", days_before=2, days_after=1).fit_transform(X)
+    holidays = HolidayTransformer(
+        country_code="DE", days_before=2, days_after=1, bridge_days=1
+    ).fit_transform(X)
+    if "double_holidays" in request.param:
+        X = X.join(HolidayTransformer(country_code="BE", days_before=0, days_after=2).fit_transform(X))
+
     return X.join(holidays)
 
 
@@ -271,7 +276,9 @@ def pipeline_instance_model_only(request):
                 (
                     "regressor",
                     ProphetWrapper(
-                        daily_seasonality=False, weekly_seasonality=False, yearly_seasonality=False,
+                        daily_seasonality=False,
+                        weekly_seasonality=False,
+                        yearly_seasonality=False,
                     ),
                 )
             ]
@@ -286,7 +293,14 @@ def pipeline_instance_model_only(request):
         return Pipeline([("regressor", get_sklearn_wrapper(LinearRegression, lags=4))])
 
     elif request.param == "sarimax":
-        return Pipeline([("regressor", SarimaxWrapper(order=(1, 1, 0), seasonal_order=(1, 1, 1, 1)),)])
+        return Pipeline(
+            [
+                (
+                    "regressor",
+                    SarimaxWrapper(order=(1, 1, 0), seasonal_order=(1, 1, 1, 1)),
+                )
+            ]
+        )
 
     elif request.param == "stacking_ensemble":
         return Pipeline(
@@ -347,16 +361,40 @@ def pipeline_instance_model_in_pipeline(request):
         )
 
     elif request.param == "smoothing":
-        return Pipeline([("model", Pipeline([("regressor", ExponentialSmoothingWrapper(trend="add"))]),)])
+        return Pipeline(
+            [
+                (
+                    "model",
+                    Pipeline([("regressor", ExponentialSmoothingWrapper(trend="add"))]),
+                )
+            ]
+        )
 
     elif request.param == "tbats":
         return Pipeline(
-            [("model", Pipeline([("regressor", TBATSWrapper(use_arma_errors=False, use_box_cox=False),)]),)]
+            [
+                (
+                    "model",
+                    Pipeline(
+                        [
+                            (
+                                "regressor",
+                                TBATSWrapper(use_arma_errors=False, use_box_cox=False),
+                            )
+                        ]
+                    ),
+                )
+            ]
         )
 
     elif request.param == "sklearn":
         return Pipeline(
-            [("model", Pipeline([("regressor", get_sklearn_wrapper(LinearRegression, lags=4))]),)]
+            [
+                (
+                    "model",
+                    Pipeline([("regressor", get_sklearn_wrapper(LinearRegression, lags=4))]),
+                )
+            ]
         )
 
     elif request.param == "sarimax":
@@ -364,7 +402,14 @@ def pipeline_instance_model_in_pipeline(request):
             [
                 (
                     "model",
-                    Pipeline([("regressor", SarimaxWrapper(order=(1, 1, 0), seasonal_order=(1, 1, 1, 1)),)]),
+                    Pipeline(
+                        [
+                            (
+                                "regressor",
+                                SarimaxWrapper(order=(1, 1, 0), seasonal_order=(1, 1, 1, 1)),
+                            )
+                        ]
+                    ),
                 )
             ]
         )
@@ -432,7 +477,8 @@ def test_data_raw():
     dfs = []
     for region in regions:
         df_tmp = pd.DataFrame(
-            columns=["date", "Region", "Plant", "Product", "Quantity"], index=range(len(dates)),
+            columns=["date", "Region", "Plant", "Product", "Quantity"],
+            index=range(len(dates)),
         )
         df_tmp.loc[:, "Region"] = region
         for plant in plants:
@@ -461,7 +507,8 @@ def train_data(request):
 
     dfs = []
     df_tmp = pd.DataFrame(
-        columns=["date", "Region", "Product", "Holidays_code", "Quantity"], index=range(len(df0.index)),
+        columns=["date", "Region", "Product", "Holidays_code", "Quantity"],
+        index=range(len(df0.index)),
     )
     for region in regions:
         df_tmp.loc[:, "Region"] = region
@@ -502,7 +549,11 @@ def grid_search(request):
 
     parameters = [
         {"model": [good_dummy]},
-        {"model": [bad_dummy], "model__strategy": ["constant"], "model__constant": [42]},
+        {
+            "model": [bad_dummy],
+            "model__strategy": ["constant"],
+            "model__constant": [42],
+        },
     ]
 
     holiday_model = Pipeline(

--- a/tests/unit/feature_extraction/test_holiday_transformer.py
+++ b/tests/unit/feature_extraction/test_holiday_transformer.py
@@ -139,3 +139,59 @@ def test_two_transformers(
 
     df_result = pipeline.fit_transform(X)
     assert_frame_equal(df_result, df_expected)
+
+
+@pytest.fixture()
+def expected_result_holidays_related_features(request):
+    if "without_related_features" in request.param:
+        result = {"_holiday_DE": ["Good Friday", "", "", "Easter Monday", "", "", "", "", "", ""]}
+
+    elif "all_related_features" in request.param:
+        result = {
+            "_holiday_DE": ["Good Friday", "", "", "Easter Monday", "", "", "", "", "", ""],
+            "_before_holiday": [False, True, True, False, False, False, False, False, False, False],
+            "_after_holiday": [False, True, True, False, True, True, False, False, False, False],
+            "_holiday_bridge_days": [False, True, True, False, False, False, False, False, False, False],
+        }
+
+    elif "features_without_bridge_days" in request.param:
+        result = {
+            "_holiday_DE": ["Good Friday", "", "", "Easter Monday", "", "", "", "", "", ""],
+            "_before_holiday": [False, False, True, False, False, False, False, False, False, False],
+            "_after_holiday": [False, True, False, False, True, False, False, False, False, False],
+        }
+
+    elif "just_before_holidays_1" in request.param:
+        result = {
+            "_holiday_DE": ["Good Friday", "", "", "Easter Monday", "", "", "", "", "", ""],
+            "_before_holiday": [False, False, True, False, False, False, False, False, False, False],
+        }
+
+    elif "bridge_days_work_just_with_after_and_before_days" in request.param:
+        result = {
+            "_holiday_DE": ["Good Friday", "", "", "Easter Monday", "", "", "", "", "", ""],
+            "_after_holiday": [False, True, False, False, True, False, False, False, False, False],
+        }
+
+    return pd.DataFrame(result, index=pd.date_range(start="2020-04-10", periods=10))
+
+
+@pytest.mark.parametrize(
+    "country_code, days_before, days_after, bridge_days, expected_result_holidays_related_features",
+    [
+        ("DE", 0, 0, False, "without_related_features"),
+        ("DE", 2, 2, True, "all_related_features"),
+        ("DE", 1, 1, False, "features_without_bridge_days"),
+        ("DE", 1, 0, False, "just_before_holidays_1"),
+        ("DE", 0, 1, True, "bridge_days_work_just_with_after_and_before_days"),
+    ],
+    indirect=["expected_result_holidays_related_features"],
+)
+def test_holidays_related_features(
+    country_code, days_before, days_after, bridge_days, expected_result_holidays_related_features
+):
+    X = pd.DataFrame(index=pd.date_range(start="2020-04-10", periods=10))
+    df_result = HolidayTransformer(
+        country_code=country_code, days_before=days_before, days_after=days_after, bridge_days=bridge_days
+    ).fit_transform(X)
+    assert_frame_equal(df_result, expected_result_holidays_related_features)

--- a/tests/unit/feature_extraction/test_holiday_transformer.py
+++ b/tests/unit/feature_extraction/test_holiday_transformer.py
@@ -35,7 +35,13 @@ from hcrystalball.feature_extraction import HolidayTransformer
             None,
             ValueError,
         ),  # cannot have country_code and country_code_column in the same time
-        ("series_with_freq_D", "LALA", None, None, ValueError,),  # country_code needs to be proper country
+        (
+            "series_with_freq_D",
+            "LALA",
+            None,
+            None,
+            ValueError,
+        ),  # country_code needs to be proper country
         (
             "series_with_freq_D",
             None,
@@ -47,7 +53,11 @@ from hcrystalball.feature_extraction import HolidayTransformer
     indirect=["X_y_with_freq"],
 )
 def test_holiday_transformer_inputs(
-    X_y_with_freq, country_code, country_code_column, country_code_column_value, extected_error,
+    X_y_with_freq,
+    country_code,
+    country_code_column,
+    country_code_column_value,
+    extected_error,
 ):
 
     X, _ = X_y_with_freq
@@ -73,7 +83,10 @@ def test_holiday_transformer_inputs(
 
 @pytest.mark.parametrize(
     "country_code, country_code_column, country_code_column_value, exp_col_name",
-    [("CZ", None, None, "_holiday_CZ"), (None, "holiday_col", "CZ", "_holiday_holiday_col")],
+    [
+        ("CZ", None, None, "_holiday_CZ"),
+        (None, "holiday_col", "CZ", "_holiday_holiday_col"),
+    ],
 )
 def test_holiday_transformer_transform(
     country_code, country_code_column, country_code_column_value, exp_col_name
@@ -110,8 +123,30 @@ def test_two_transformers(
     first_suffix = country_code_first or country_code_column_first
     second_suffix = country_code_second or country_code_column_second
     expected = {
-        f"_holiday_{first_suffix}": ["Labour Day", "", "", "", "", "", "", "Liberation Day", "", ""],
-        f"_holiday_{second_suffix}": ["Labour Day", "", "", "", "", "", "", "Liberation Day", "", ""],
+        f"_holiday_{first_suffix}": [
+            "Labour Day",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "Liberation Day",
+            "",
+            "",
+        ],
+        f"_holiday_{second_suffix}": [
+            "Labour Day",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "Liberation Day",
+            "",
+            "",
+        ],
     }
     X = pd.DataFrame(index=pd.date_range(start="2019-05-01", periods=10))
     df_expected = pd.DataFrame(expected, index=X.index)
@@ -125,13 +160,15 @@ def test_two_transformers(
             (
                 f"holidays_{first_suffix}",
                 HolidayTransformer(
-                    country_code_column=country_code_column_first, country_code=country_code_first
+                    country_code_column=country_code_column_first,
+                    country_code=country_code_first,
                 ),
             ),
             (
                 f"holidays_{second_suffix}",
                 HolidayTransformer(
-                    country_code_column=country_code_column_second, country_code=country_code_second
+                    country_code_column=country_code_column_second,
+                    country_code=country_code_second,
                 ),
             ),
         ]
@@ -144,33 +181,167 @@ def test_two_transformers(
 @pytest.fixture()
 def expected_result_holidays_related_features(request):
     if "without_related_features" in request.param:
-        result = {"_holiday_DE": ["Good Friday", "", "", "Easter Monday", "", "", "", "", "", ""]}
+        result = {
+            "_holiday_DE": [
+                "Good Friday",
+                "",
+                "",
+                "Easter Monday",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+            ]
+        }
 
     elif "all_related_features" in request.param:
         result = {
-            "_holiday_DE": ["Good Friday", "", "", "Easter Monday", "", "", "", "", "", ""],
-            "_2_before_holiday_DE": [False, True, True, False, False, False, False, False, False, False],
-            "_2_after_holiday_DE": [False, True, True, False, True, True, False, False, False, False],
-            "_bridge_holiday_DE": [False, True, True, False, False, False, False, False, False, False],
+            "_holiday_DE": [
+                "Good Friday",
+                "",
+                "",
+                "Easter Monday",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+            ],
+            "_2_before_holiday_DE": [
+                False,
+                True,
+                True,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+            ],
+            "_2_after_holiday_DE": [
+                False,
+                True,
+                True,
+                False,
+                True,
+                True,
+                False,
+                False,
+                False,
+                False,
+            ],
+            "_bridge_holiday_DE": [
+                False,
+                True,
+                True,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+            ],
         }
 
     elif "features_without_bridge_days" in request.param:
         result = {
-            "_holiday_DE": ["Good Friday", "", "", "Easter Monday", "", "", "", "", "", ""],
-            "_1_before_holiday_DE": [False, False, True, False, False, False, False, False, False, False],
-            "_1_after_holiday_DE": [False, True, False, False, True, False, False, False, False, False],
+            "_holiday_DE": [
+                "Good Friday",
+                "",
+                "",
+                "Easter Monday",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+            ],
+            "_1_before_holiday_DE": [
+                False,
+                False,
+                True,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+            ],
+            "_1_after_holiday_DE": [
+                False,
+                True,
+                False,
+                False,
+                True,
+                False,
+                False,
+                False,
+                False,
+                False,
+            ],
         }
 
     elif "just_before_holidays_1" in request.param:
         result = {
-            "_holiday_DE": ["Good Friday", "", "", "Easter Monday", "", "", "", "", "", ""],
-            "_1_before_holiday_DE": [False, False, True, False, False, False, False, False, False, False],
+            "_holiday_DE": [
+                "Good Friday",
+                "",
+                "",
+                "Easter Monday",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+            ],
+            "_1_before_holiday_DE": [
+                False,
+                False,
+                True,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+            ],
         }
 
     elif "bridge_days_work_just_with_after_and_before_days" in request.param:
         result = {
-            "_holiday_DE": ["Good Friday", "", "", "Easter Monday", "", "", "", "", "", ""],
-            "_1_after_holiday_DE": [False, True, False, False, True, False, False, False, False, False],
+            "_holiday_DE": [
+                "Good Friday",
+                "",
+                "",
+                "Easter Monday",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+            ],
+            "_1_after_holiday_DE": [
+                False,
+                True,
+                False,
+                False,
+                True,
+                False,
+                False,
+                False,
+                False,
+                False,
+            ],
         }
 
     return pd.DataFrame(result, index=pd.date_range(start="2020-04-10", periods=10))
@@ -188,7 +359,14 @@ def expected_result_holidays_related_features(request):
         ("DE", 2, 2, True, "all_related_features", None),
         ("DE", 1, 1, False, "features_without_bridge_days", None),
         ("DE", 1, 0, False, "just_before_holidays_1", None),
-        ("DE", 0, 1, True, "bridge_days_work_just_with_after_and_before_days", ValueError),
+        (
+            "DE",
+            0,
+            1,
+            True,
+            "bridge_days_work_just_with_after_and_before_days",
+            ValueError,
+        ),
     ],
     indirect=["expected_result_holidays_related_features"],
 )
@@ -203,7 +381,10 @@ def test_holidays_related_features(
     X = pd.DataFrame(index=pd.date_range(start="2020-04-10", periods=10))
     if extected_error is None:
         df_result = HolidayTransformer(
-            country_code=country_code, days_before=days_before, days_after=days_after, bridge_days=bridge_days
+            country_code=country_code,
+            days_before=days_before,
+            days_after=days_after,
+            bridge_days=bridge_days,
         ).fit_transform(X)
         assert_frame_equal(df_result, expected_result_holidays_related_features)
 

--- a/tests/unit/wrappers/test_prophet_wrapper.py
+++ b/tests/unit/wrappers/test_prophet_wrapper.py
@@ -8,13 +8,20 @@ from hcrystalball.wrappers import ProphetWrapper
 @pytest.mark.parametrize(
     "X_with_holidays, extra_holidays",
     [
-        ("", {"New year": {"prior_scale": 100}, "Whit Monday": {"lower_window": -2, "prior_scale": 10}}),
+        (
+            "",
+            {
+                "New year": {"prior_scale": 100},
+                "Whit Monday": {"lower_window": -2, "prior_scale": 10},
+            },
+        ),
         ("", {"New year": {"prior_scale": 100, "lower_window": -1}}),
         ("", None),
     ],
     indirect=["X_with_holidays"],
 )
 def test_prophet_adjust_holidays(X_with_holidays, extra_holidays):
+
     prophet = ProphetWrapper(extra_holidays=extra_holidays)
     prophet.model = prophet._init_tsmodel(Prophet)
     X = prophet._adjust_holidays(X_with_holidays)
@@ -33,6 +40,122 @@ def test_prophet_adjust_holidays(X_with_holidays, extra_holidays):
                     holidays.loc[holidays["holiday"] == holiday_name + "_DE", params_key].values[0]
                     == params_values
                 )
+
+
+@pytest.fixture(scope="module")
+def expected_result_prophet_adjust_holidays_related_features():
+
+    result = {
+        "holiday": [
+            "New year_BE",
+            "Easter Monday_BE",
+            "Labour Day_BE",
+            "Ascension Thursday_BE",
+            "Whit Monday_BE",
+            "National Day_BE",
+            "Assumption of Mary to Heaven_BE",
+            "New year_DE",
+            "Good Friday_DE",
+            "Easter Monday_DE",
+            "Labour Day_DE",
+            "Ascension Thursday_DE",
+            "Whit Monday_DE",
+            "Day of German Unity_DE",
+        ],
+        "lower_window": [
+            -4.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            -4.0,
+            2.0,
+            2.0,
+            2.0,
+            2.0,
+            2.0,
+            2.0,
+        ],
+        "upper_window": [
+            2.0,
+            2.0,
+            2.0,
+            2.0,
+            2.0,
+            2.0,
+            2.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+        ],
+        "prior_scale": [
+            100.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            100.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+        ],
+        "ds": [
+            "2019-01-01",
+            "2019-04-22",
+            "2019-05-01",
+            "2019-05-30",
+            "2019-06-10",
+            "2019-07-21",
+            "2019-08-15",
+            "2019-01-01",
+            "2019-04-19",
+            "2019-04-22",
+            "2019-05-01",
+            "2019-05-30",
+            "2019-06-10",
+            "2019-10-03",
+        ],
+    }
+
+    return pd.DataFrame(result).assign(ds=lambda df: pd.to_datetime(df["ds"]))
+
+
+@pytest.mark.parametrize(
+    "X_with_holidays, extra_holidays, expected_result_prophet_adjust_holidays_for_two_countries",
+    [
+        (
+            "double_holidays",
+            {"New year": {"prior_scale": 100, "lower_window": -4}},
+            "double_holidays",
+        )
+    ],
+    indirect=[
+        "X_with_holidays",
+        "expected_result_prophet_adjust_holidays_for_two_countries",
+    ],
+)
+def test_prophet_adjust_holidays_related_features(
+    X_with_holidays,
+    extra_holidays,
+    expected_result_prophet_adjust_holidays_for_two_countries,
+):
+
+    prophet = ProphetWrapper(extra_holidays=extra_holidays)
+    prophet.model = prophet._init_tsmodel(Prophet)
+    prophet._adjust_holidays(X_with_holidays)
+    holidays = prophet.model.holidays
+    assert_frame_equal(holidays, expected_result_prophet_adjust_holidays_for_two_countries)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/wrappers/test_prophet_wrapper.py
+++ b/tests/unit/wrappers/test_prophet_wrapper.py
@@ -132,7 +132,7 @@ def expected_result_prophet_adjust_holidays_related_features():
 
 
 @pytest.mark.parametrize(
-    "X_with_holidays, extra_holidays, expected_result_prophet_adjust_holidays_for_two_countries",
+    "X_with_holidays, extra_holidays, expected_result_prophet_adjust_holidays_related_features",
     [
         (
             "double_holidays",
@@ -142,20 +142,20 @@ def expected_result_prophet_adjust_holidays_related_features():
     ],
     indirect=[
         "X_with_holidays",
-        "expected_result_prophet_adjust_holidays_for_two_countries",
+        "expected_result_prophet_adjust_holidays_related_features",
     ],
 )
 def test_prophet_adjust_holidays_related_features(
     X_with_holidays,
     extra_holidays,
-    expected_result_prophet_adjust_holidays_for_two_countries,
+    expected_result_prophet_adjust_holidays_related_features,
 ):
 
     prophet = ProphetWrapper(extra_holidays=extra_holidays)
     prophet.model = prophet._init_tsmodel(Prophet)
     prophet._adjust_holidays(X_with_holidays)
     holidays = prophet.model.holidays
-    assert_frame_equal(holidays, expected_result_prophet_adjust_holidays_for_two_countries)
+    assert_frame_equal(holidays, expected_result_prophet_adjust_holidays_related_features)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
@MichalChromcak please take a look.

**Reasoning behind the PR**
This PR aims to improve the handling of holidays effects around public holidays and during specific days. In particular, it helps to model situations when there are just one/few working days between two public holidays, Christmas and other periods with low economic activity without explicit public holidays, special days like first/last day of the year which is often not a public holiday but has a similar effect. The end/start of month/quarter is frequently connected with business processes (budgeting period) which have natural influences on numerous time series. 

**Implemented changes:**
HolidayTransformer extended by 3 new parameters - days_before, days_after, bridge_days - all of them are inactive by default
-  days_before means how many days before public holiday should be taken into account (i.e. 2 means that 2 days before public holidays will be True), creates 1 column
- days_after - the same logic applies as in case of days_before
- bridge_days is bool parameter meaning whether to create bool feature marking days between holidays - these bridge days are created as the overlap between days_before and days_after, this implies that bridge day feature can be created only if days_before and days_after are both > 0

SeasonalityTransformer was extended by 6 new features -  all of them are inactive by default:   "_month_start", "_month_end",  "_quarter_start",  "_quarter_end", "_year_start", "_year_end",