### PR TITLE
force python3 kernel name for nbsphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,3 +73,4 @@ automodsumm_inherited_members = True
 
 # Handling notebook execution
 nbsphinx_execute = os.getenv("NBSPHINX_EXECUTE", "auto")
+nbsphinx_kernel_name = "python3"


### PR DESCRIPTION
Fixes #42 