### PR TITLE
Fix problem with unstable models which are picked during CV

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - pandas=1.0
 - numpy=1.18
 - scikit-learn=0.23
-- workalendar=10.1 # for HolidayTransformer
+- workalendar=14.1 # for HolidayTransformer
 - statsmodels=0.12 # SmoothingWrappers
 - fbprophet=0.6 # ProphetWrapper
 - matplotlib-base=3.2.2 # for plotting in model selection

--- a/src/hcrystalball/model_selection/__init__.py
+++ b/src/hcrystalball/model_selection/__init__.py
@@ -1,6 +1,7 @@
 from ._large_scale_cross_validation import select_model
 from ._large_scale_cross_validation import run_model_selection
 from ._large_scale_cross_validation import select_model_general
+from ._large_scale_cross_validation import get_best_not_failing_model
 from ._configuration import get_gridsearch
 from ._configuration import add_model_to_gridsearch
 from ._split import FinerTimeSplit
@@ -30,4 +31,5 @@ __all__ = [
     "run_model_selection",
     "select_model",
     "select_model_general",
+    "get_best_not_failing_model",
 ]

--- a/src/hcrystalball/model_selection/_large_scale_cross_validation.py
+++ b/src/hcrystalball/model_selection/_large_scale_cross_validation.py
@@ -45,9 +45,9 @@ def make_progress_bar(*args, **kwargs):
 
 def get_best_not_failing_model(grid_search, X, y):
     """
-    Prevent situation when model incompatible data are not seen during CV (there the last split actuals) and
-    model which cannot be fitted on the full dataset is choseen. In such a situation the next model with lower
-    test score should be selected.
+    Prevent situation when model incompatible data are not seen during CV (in the last split of actuals) and
+    model which cannot be fitted on the full dataset is choseen. In such a situation the next model with the
+    lowest test score should be selected.
 
     Parameters
     ----------

--- a/src/hcrystalball/model_selection/_large_scale_cross_validation.py
+++ b/src/hcrystalball/model_selection/_large_scale_cross_validation.py
@@ -43,6 +43,49 @@ def make_progress_bar(*args, **kwargs):
     return pbar
 
 
+def get_best_not_failing_model(grid_search, X, y):
+    """
+    Prevent situation when model incompatible data are not seen during CV (there the last split actuals) and
+    model which cannot be fitted on the full dataset is choseen. In such a situation the next model with lower
+    test score should be selected.
+
+    Parameters
+    ----------
+    grid_search : sklearn.model_selection.GridSearchCV
+        Fitted instance compatible with Sklearn GridSearchCV
+
+    X : pandas.DataFrame
+            Input features.
+
+    y : array_like, (1d)
+            Target vector.
+
+    Returns
+    -------
+    dict
+        with keys `rank` and `params`
+
+    Raises
+    ------
+    ValueError
+        No available model could be fit on given data
+    """
+    params_ranks = (
+        pd.DataFrame(grid_search.cv_results_)[["rank_test_score", "params"]]
+        .sort_values("rank_test_score")
+        .to_dict("records")
+    )
+
+    for param_rank in params_ranks:
+        try:
+            grid_search.estimator.set_params(**param_rank["params"]).fit(X, y)
+            return {"rank": param_rank["rank_test_score"], "params": param_rank["params"]}
+        except Exception:
+            continue
+
+    raise ValueError("No available model could be fit on given data")
+
+
 def select_model(
     df,
     target_col_name,
@@ -121,12 +164,14 @@ def select_model(
 
         # searches among all models with found best Sarimax on last split (as opose to using AutoSarimax)
         grid_search_tmp.fit(X, y)
+        best_param_rank = get_best_not_failing_model(grid_search_tmp, X, y)
         # add convenient result object
         results.append(
             ModelSelectorResult(
                 # more robust refit=True that makes sure, that models failing during fit
                 # are ommited even if exception happens in wrapper's model's __init__
-                best_model=grid_search_tmp.estimator.set_params(**grid_search_tmp.best_params_).fit(X, y),
+                best_model=grid_search_tmp.estimator.set_params(**best_param_rank["params"]).fit(X, y),
+                best_model_rank=best_param_rank["rank"],
                 cv_results=pd.DataFrame(grid_search_tmp.cv_results_),
                 cv_data=grid_search_tmp.scorer_.cv_data,
                 model_reprs=grid_search_tmp.scorer_.estimator_ids,

--- a/src/hcrystalball/model_selection/_model_selector_result.py
+++ b/src/hcrystalball/model_selection/_model_selector_result.py
@@ -65,6 +65,7 @@ class ModelSelectorResult:
         frequency,
         horizon,
         country_code_column,
+        best_model_rank,
     ):
         self.best_model = best_model
         self.cv_results = cv_results
@@ -76,13 +77,16 @@ class ModelSelectorResult:
         self.frequency = frequency
         self.horizon = horizon
         self.country_code_column = country_code_column
+        self.best_model_rank = best_model_rank
 
         self.best_model_hash = generate_estimator_hash(best_model)
         self.best_model_cv_data = self.cv_data.rename({self.best_model_hash: "best_model"}, axis=1)[
             ["split", "y_true", "best_model"]
         ]
         self.best_model_name = get_estimator_name(best_model).replace("model__", "")
-        self.best_model_cv_results = self.cv_results[self.cv_results["rank_test_score"] == 1].iloc[0]
+        self.best_model_cv_results = self.cv_results[
+            self.cv_results["rank_test_score"] == self.best_model_rank
+        ].iloc[0]
         self.best_model_repr = self.model_reprs[self.best_model_hash]
         self.partition_hash = generate_partition_hash(self.partition)
 

--- a/tests/unit/model_selection/test_model_selection.py
+++ b/tests/unit/model_selection/test_model_selection.py
@@ -1,4 +1,14 @@
+from sklearn.pipeline import Pipeline
+from sklearn.model_selection import GridSearchCV
+from sklearn.dummy import DummyRegressor
+import numpy as np
+
+from hcrystalball.wrappers import ExponentialSmoothingWrapper
+from hcrystalball.wrappers import get_sklearn_wrapper
+from hcrystalball.model_selection import FinerTimeSplit
+from hcrystalball.metrics import get_scorer
 from hcrystalball.model_selection import select_model
+from hcrystalball.model_selection import get_best_not_failing_model
 import pytest
 
 
@@ -39,3 +49,44 @@ def test_select_model(train_data, grid_search, parallel_over_dict):
     for result in results:
         assert result.best_model_name == "good_dummy"
         assert result.partition in partitions
+
+
+@pytest.mark.parametrize(
+    "X_y_optional, negative_data, best_model_name, rank, expected_error",
+    [
+        ("", False, "ExponentialSmoothingWrapper", 1, None),
+        ("", True, "SklearnWrapper", 2, None),
+        ("", True, "", 2, ValueError),
+    ],
+    indirect=["X_y_optional"],
+)
+def test_get_best_not_failing_model(X_y_optional, negative_data, best_model_name, rank, expected_error):
+    X, y = X_y_optional
+    # data contains 0
+    y[y < 1] = 1
+    if negative_data:
+        y[-1] = -1
+    models = [
+        ExponentialSmoothingWrapper(freq="D", seasonal="mul"),
+        get_sklearn_wrapper(DummyRegressor, strategy="constant", constant=-1000),
+    ]
+    models = models if expected_error is None else models[:1]
+    grid_search = GridSearchCV(
+        estimator=Pipeline([("model", "passthrough")]),
+        param_grid=[{"model": models}],
+        scoring=get_scorer("neg_mean_absolute_error"),
+        cv=FinerTimeSplit(n_splits=1, horizon=5),
+        refit=False,
+        error_score=np.nan,
+    )
+
+    grid_search.fit(X, y)
+
+    if expected_error:
+        with pytest.raises(expected_error):
+            get_best_not_failing_model(grid_search, X, y)
+    else:
+        best_param_rank = get_best_not_failing_model(grid_search, X, y)
+        assert isinstance(best_param_rank, dict)
+        assert best_param_rank["params"]["model"].__class__.__name__ == best_model_name
+        assert best_param_rank["rank"] == rank


### PR DESCRIPTION
Prevent situation when model incompatible data are not seen during CV (in the last split of actuals) and model which cannot be fitted on the full dataset is chosen. In such a situation the next model with the second-best error should be choosen.